### PR TITLE
chore: Switch to self-hosted GitHub agents

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -17,7 +17,7 @@ jobs:
           - flags: -v -race
           - flags: -v
 
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-x64
     steps:
       - name: Checkout
         uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2


### PR DESCRIPTION
Updated GitHub workflow files to use self-hosted agents instead of GitHub-hosted runners